### PR TITLE
Update tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leaky-bucket"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["John-John Tedro <udoprog@tedro.se>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["algorithms", "network-programming", "concurrency"]
 [dependencies]
 futures-channel = "0.3.1"
 futures-util = "0.3.1"
-tokio = { version = "0.2.4", features = ["time", "stream"] }
+tokio = { version = "0.2.13", features = ["time", "stream", "rt-core"] }
 log = "0.4.7"
 lazy_static = { version = "1.4.0", optional = true }
 thiserror = "1.0.9"


### PR DESCRIPTION
Newer versions of tokio require the "rt-core" feature to be enabled for tokio::spawn to be available. This adds the feature and also updates tokio to the latest 0.2 version.