### PR TITLE
More tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,8 @@ Futures-aware rate limiter implementation.
 categories = ["algorithms", "network-programming", "concurrency"]
 
 [dependencies]
-futures-channel = "0.3.1"
 futures-util = "0.3.1"
-tokio = { version = "0.2.13", features = ["time", "stream"] }
+tokio = { version = "0.2.22", features = ["time", "stream", "sync"] }
 log = "0.4.7"
 lazy_static = { version = "1.4.0", optional = true }
 thiserror = "1.0.9"

--- a/tests/issue5.rs
+++ b/tests/issue5.rs
@@ -1,0 +1,51 @@
+use leaky_bucket::LeakyBuckets;
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn test_issue5_a() {
+    let mut buckets = LeakyBuckets::new();
+    let coordinator = buckets.coordinate().unwrap();
+    tokio::spawn(async move { coordinator.await.unwrap() });
+
+    let rate_limiter = buckets
+        .rate_limiter()
+        .refill_amount(1)
+        .refill_interval(Duration::from_millis(100))
+        .build()
+        .expect("LeakyBucket builder failed");
+
+    let begin = Instant::now();
+
+    for _ in 0..10 {
+        rate_limiter.acquire_one().await.expect("No reason to fail");
+    }
+
+    let elapsed = Instant::now().duration_since(begin);
+    println!("Elapsed: {:?}", elapsed);
+    assert!((elapsed.as_secs_f64() - 1.).abs() < 0.1);
+}
+
+#[tokio::test]
+async fn test_issue5_b() {
+    let mut buckets = LeakyBuckets::new();
+    let coordinator = buckets.coordinate().unwrap();
+    tokio::spawn(async move { coordinator.await.unwrap() });
+
+    let rate_limiter = buckets
+        .rate_limiter()
+        .refill_amount(1)
+        .refill_interval(Duration::from_secs(2))
+        .build()
+        .expect("LeakyBucket builder failed");
+
+    let begin = Instant::now();
+
+    for _ in 0..2 {
+        rate_limiter.acquire_one().await.expect("No reason to fail");
+    }
+
+    let elapsed = Instant::now().duration_since(begin);
+    println!("Elapsed: {:?}", elapsed);
+    // once per 2 seconds => 4 seconds for 2 permits
+    assert!((elapsed.as_secs_f64() - 4.).abs() < 0.1);
+}


### PR DESCRIPTION
While troubleshooting #5 I took the time to rewrite the `acquire` logic to use an `async` fn. Wakeup notification is now handled using a [`oneshot`](https://docs.rs/tokio/0/tokio/sync/oneshot/index.html) instead of the `Waker` / `AtomicBool` pair.