### PR TITLE
Store tasks to wake up locally in order to make coordinator more fair

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ static = ["lazy_static", "tokio/rt-core"]
 
 [dev-dependencies]
 futures = "0.3.1"
-tokio = { version = "0.2.4", features = ["macros", "rt-core"] }
+tokio = { version = "0.2.4", features = ["full"] }

--- a/tests/test_rate_limit_target.rs
+++ b/tests/test_rate_limit_target.rs
@@ -1,0 +1,51 @@
+use leaky_bucket::LeakyBuckets;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Test that a bunch of threads spinning on a rate limiter refilling a
+/// reasonable amount of tokens at a slowish rate reaches the given target.
+#[tokio::test]
+async fn test_rate_limit_target() {
+    let mut buckets = LeakyBuckets::new();
+    let coordinator = buckets.coordinate().unwrap();
+    tokio::spawn(async move { coordinator.await.unwrap() });
+
+    let rate_limiter = buckets
+        .rate_limiter()
+        .refill_amount(50)
+        .refill_interval(Duration::from_millis(200))
+        .build()
+        .expect("LeakyBucket builder failed");
+
+    let rate_limiter = Arc::new(rate_limiter);
+    let c = Arc::new(AtomicUsize::new(0));
+
+    let start = Instant::now();
+
+    let mut tasks = Vec::new();
+
+    for _ in 0..100 {
+        let rate_limiter = rate_limiter.clone();
+        let c = c.clone();
+
+        tasks.push(tokio::spawn(async move {
+            while c.fetch_add(1, Ordering::SeqCst) < 500 {
+                rate_limiter.acquire_one().await.unwrap();
+            }
+        }));
+    }
+
+    for t in tasks {
+        t.await.unwrap();
+    }
+
+    let duration = Instant::now().duration_since(start);
+
+    let diff = duration.as_millis() as f32 - 2000f32;
+    assert!(
+        diff.abs() < 10f32,
+        "diff must be less than 10ms, but was {}ms",
+        diff
+    );
+}


### PR DESCRIPTION
This resurrects the local task queue that was used in `0.7` for the coordinator, which consumes the tasks to be woken up more eagerly than what is currently done. This should avoid tasks being overly stuck in the task queue.

Do note that the "fast path" is still best effort. And spurious slowdowns of one refill cycle or more can still happen under the right conditions (a task is added while the fast path is being refilled). So the error one should be expecting should be around one or two refill cycles depending on circumstances.

This was reported here: https://github.com/udoprog/leaky-bucket/issues/5#issuecomment-703290390 and created as an issue in #9

@xnuter - please take it for a spin