### PR TITLE
Update tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ categories = ["algorithms", "network-programming", "concurrency"]
 
 [dependencies]
 futures-util = "0.3.1"
-tokio = { version = "0.3.0", features = ["macros", "time", "stream", "sync"] }
+tokio = { version = "1", features = ["macros", "time", "sync"] }
+tokio-stream = "0.1.0"
 log = "0.4.7"
 lazy_static = { version = "1.4.0", optional = true }
 thiserror = "1.0.9"
@@ -26,4 +27,4 @@ static = ["lazy_static", "tokio/rt"]
 
 [dev-dependencies]
 futures = "0.3.1"
-tokio = { version = "0.3.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
-use tokio::stream::StreamExt as _;
 use tokio::sync::{mpsc, oneshot};
+use tokio_stream::StreamExt as _;
 
 #[cfg(feature = "static")]
 lazy_static::lazy_static! {
@@ -737,7 +737,7 @@ mod tests {
         let delay = time::sleep(Duration::from_millis(200));
 
         let task = future::select(one.boxed(), two.boxed());
-        let task = future::select(task, delay);
+        let task = future::select(task, delay.boxed());
 
         future::select(task, buckets.coordinate().unwrap().boxed()).await;
 


### PR DESCRIPTION
Use tokio_stream crate, since the tokio 1.0.0 release removed stream.

https://tokio.rs/blog/2020-12-tokio-1-0#stream