### PR TITLE
Remove some unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["algorithms", "concurrency", "network-programming"]
 parking_lot = "0.12.1"
 tokio = { version = "1.28.1", features = ["time"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
At Neon, we recently had a panic triggered in tokio RawTask Waker functions, specifically about mismatched ref counts, it appeared in the callstack of leaky-bucket. We didn't find anything wrong in the tokio code, but given leaky-bucket was in the stack frame, I started looking here.

While necessary for intrusive linked lists, this code has a lot of unsafe. I ran it through miri (I had to enable the start_paused flag with tokio mocked time to do so) but didn't find anything. However, in the process, I realised there was some low-hanging unsafe code to clean up.

Main changes:
1. pin-project-lite is already a dependency through tokio, so we might as well use it instead of writing manual unsafe projections.
2. The code with the UnsafeCell was written using manual pointer offsets, even through `&mut`. UnsafeCell has a safe `get_mut` method which we can just use instead. This also fixed the pointer accesses in the `&self` versions to use `addr_of` instead of pointer offsets.

The first commit in this PR does have a noticeable change in a few of the docs. I am open to reverting those changes. However, in the `tests/` it makes the tests deterministic. I had trouble running the tests because they would take a couple milliseconds more than expected and fail. They are also slow tests. Using mocked tokio time makes them instant and also deterministic.

Unfortunately I haven't yet found the source of the bug, but I thought I would upstream these changes regardless. I'm also exploring a significant rewrite to remove almost all unsafe by using https://docs.rs/pin-list/latest/pin_list/ as the linkedlist impl, and not write our own, but it's more than I can pull off with the time I have right now. I started on that work in a branch if you're curious https://github.com/conradludgate/leaky-bucket/commit/bd42c2ed081e1b5dd59eec51a1b4671644e92126