### PR TITLE
Use a bit less unsafe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,9 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{matrix.rust}}
-    - run: cargo build --workspace
-    - run: cargo test --all-targets
+    - run: cargo build
+    - run: cargo build --features tracing
+    - run: cargo test --all-targets --all-features
       if: matrix.rust == 'stable'
     - run: cargo test --doc
       if: matrix.rust == 'stable'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,14 @@ license = "MIT OR Apache-2.0"
 keywords = ["async", "futures", "ratelimit", "throttle", "tokenbucket"]
 categories = ["algorithms", "concurrency", "network-programming"]
 
+[features]
+default = []
+tracing = ["dep:tracing"]
+
 [dependencies]
 parking_lot = "0.12.1"
 tokio = { version = "1.28.1", features = ["time"] }
-tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
+tracing = { version = "0.1.37", default-features = false, features = ["attributes"], optional = true }
 
 [dev-dependencies]
 anyhow = "1.0.71"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,8 +238,7 @@ macro_rules! trace {
     ($($arg:tt)*) => {};
 }
 
-#[doc(hidden)]
-pub mod linked_list;
+mod linked_list;
 use self::linked_list::{LinkedList, Node};
 
 /// Default factor for how to calculate max refill value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,6 @@ use core::marker;
 use core::mem;
 use core::pin::Pin;
 use core::ptr;
-use core::ptr::addr_of;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::{Context, Poll, Waker};
 
@@ -829,30 +828,24 @@ impl AcquireState {
     /// Access the completion flag.
     pub fn complete(&self) -> &AtomicBool {
         // Safety: This is always safe to access since it's atomic.
-        unsafe {
-            let ptr = addr_of!((*self.linking.get()).complete);
-            &*ptr
-        }
+        unsafe { &*ptr::addr_of!((*self.linking.get()).complete) }
     }
 
     /// Get the underlying task.
     pub unsafe fn task(&self) -> &Node<Task> {
-        unsafe {
-            let ptr = addr_of!((*self.linking.get()).task);
-            &*ptr
-        }
+        &*ptr::addr_of!((*self.linking.get()).task)
     }
 
     /// Get the underlying task mutably.
-    pub fn task_mut(&mut self) -> &mut Node<Task> {
-        &mut self.linking.get_mut().task
+    pub unsafe fn task_mut(&mut self) -> &mut Node<Task> {
+        &mut *ptr::addr_of_mut!((*self.linking.get()).task)
     }
 
     /// Get the underlying task mutably and completion flag as a pair.
-    pub fn update_project(&mut self) -> (&mut Node<Task>, &AtomicBool, &mut bool) {
-        let node = self.linking.get_mut();
-        let complete = &node.complete;
-        let node = &mut node.task;
+    pub unsafe fn update_project(&mut self) -> (&mut Node<Task>, &AtomicBool, &mut bool) {
+        let node = self.linking.get();
+        let complete = &*ptr::addr_of!((*node).complete);
+        let node = &mut *ptr::addr_of_mut!((*node).task);
         (node, complete, &mut self.linked)
     }
 
@@ -862,7 +855,7 @@ impl AcquireState {
     fn update(&mut self, critical: &mut MutexGuard<'_, Critical>, waker: &Waker) {
         // Safety: we're ensured to do this under the critical lock since we've
         // passed the relevant guard in through `waiters`.
-        let (task, complete, linked) = self.update_project();
+        let (task, complete, linked) = unsafe { self.update_project() };
 
         if !*linked {
             trace!("linking self");
@@ -1032,7 +1025,7 @@ impl AcquireState {
             //
             // Safety: we know that no one else holds the task at this point.
             // The in particular the task is not linked into the wait queue.
-            let c = self.task_mut();
+            let c = unsafe { self.task_mut() };
             c.fill(&mut critical.balance);
             c.is_completed()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ use core::marker;
 use core::mem;
 use core::pin::Pin;
 use core::ptr;
+use core::ptr::addr_of;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::{Context, Poll, Waker};
 
@@ -829,30 +830,29 @@ impl AcquireState {
     pub fn complete(&self) -> &AtomicBool {
         // Safety: This is always safe to access since it's atomic.
         unsafe {
-            let ptr = self.linking.get() as *const _ as *const Node<Task>;
-            let ptr = ptr.add(1) as *const AtomicBool;
+            let ptr = addr_of!((*self.linking.get()).complete);
             &*ptr
         }
     }
 
     /// Get the underlying task.
     pub unsafe fn task(&self) -> &Node<Task> {
-        let ptr = self.linking.get() as *mut Node<Task>;
-        &*ptr
+        unsafe {
+            let ptr = addr_of!((*self.linking.get()).task);
+            &*ptr
+        }
     }
 
     /// Get the underlying task mutably.
-    pub unsafe fn task_mut(&mut self) -> &mut Node<Task> {
-        let ptr = self.linking.get() as *mut Node<Task>;
-        &mut *ptr
+    pub fn task_mut(&mut self) -> &mut Node<Task> {
+        &mut self.linking.get_mut().task
     }
 
     /// Get the underlying task mutably and completion flag as a pair.
-    pub unsafe fn update_project(&mut self) -> (&mut Node<Task>, &AtomicBool, &mut bool) {
-        let node = self.linking.get() as *mut Node<Task>;
-        let complete = node.add(1) as *const _ as *const AtomicBool;
-        let node = &mut *(node as *mut Node<Task>);
-        let complete = &*complete;
+    pub fn update_project(&mut self) -> (&mut Node<Task>, &AtomicBool, &mut bool) {
+        let node = self.linking.get_mut();
+        let complete = &node.complete;
+        let node = &mut node.task;
         (node, complete, &mut self.linked)
     }
 
@@ -862,7 +862,7 @@ impl AcquireState {
     fn update(&mut self, critical: &mut MutexGuard<'_, Critical>, waker: &Waker) {
         // Safety: we're ensured to do this under the critical lock since we've
         // passed the relevant guard in through `waiters`.
-        let (task, complete, linked) = unsafe { self.update_project() };
+        let (task, complete, linked) = self.update_project();
 
         if !*linked {
             trace!("linking self");
@@ -1032,7 +1032,7 @@ impl AcquireState {
             //
             // Safety: we know that no one else holds the task at this point.
             // The in particular the task is not linked into the wait queue.
-            let c = unsafe { &mut *self.task_mut() };
+            let c = self.task_mut();
             c.fill(&mut critical.balance);
             c.is_completed()
         }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -46,6 +46,12 @@ impl<T> Node<T> {
         }
     }
 
+    /// Access the value in the node.
+    #[inline]
+    pub(crate) fn value(&self) -> &T {
+        &self.value
+    }
+
     /// Get the next node.
     unsafe fn next(&self) -> Option<ptr::NonNull<Self>> {
         let ptr = self.pointers.get() as *const _ as *const Option<ptr::NonNull<Self>>;

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -6,8 +6,6 @@ use core::marker;
 use core::ops;
 use core::ptr;
 
-use tracing::trace;
-
 #[repr(C)]
 struct Pointers<T> {
     /// The next node.
@@ -165,7 +163,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(*a, 1);
     /// assert_eq!(*b, 2);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn push_front(&mut self, mut node: ptr::NonNull<Node<T>>) {
         debug_assert!(node.as_ref().next().is_none());
         debug_assert!(node.as_ref().prev().is_none());
@@ -221,7 +219,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(*a, 2);
     /// assert_eq!(*b, 1);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn push_back(&mut self, mut node: ptr::NonNull<Node<T>>) {
         trace!(head = ?self.head, tail = ?self.tail, node = ?node, "push_back");
 
@@ -266,7 +264,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(*a, 1);
     /// assert_eq!(*b, 2);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn pop_front(&mut self) -> Option<ptr::NonNull<Node<T>>> {
         trace!(head = ?self.head, tail = ?self.tail, "pop_front");
 
@@ -315,7 +313,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(*a, 2);
     /// assert_eq!(*b, 1);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn pop_back(&mut self) -> Option<ptr::NonNull<Node<T>>> {
         trace!(head = ?self.head, tail = ?self.tail, "pop_back");
 
@@ -373,7 +371,7 @@ impl<T> LinkedList<T> {
     /// assert_eq!(*c, 1);
     /// assert_eq!(*d, 0);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn remove(&mut self, mut node: ptr::NonNull<Node<T>>) {
         trace!(head = ?self.head, tail = ?self.tail, node = ?node, "remove");
 
@@ -425,7 +423,7 @@ impl<T> LinkedList<T> {
     ///
     /// assert_eq!(*a, 1);
     /// ```
-    #[tracing::instrument(level = "trace")]
+    #[cfg_attr(feature = "tracing", tracing::instrument(level = "trace"))]
     pub unsafe fn front_mut(&mut self) -> Option<ptr::NonNull<Node<T>>> {
         self.head
     }


### PR DESCRIPTION
This adopts part of, and supersedes #18, I've opted to not introduce pin-project-lite since I don't want to introduce it as a dependency. I've also adopted a slightly different strategy for avoiding unsafe by accessing internal state through a closure.