### PR TITLE
Re-implement fast-path and test for numerical limits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1077,10 +1077,10 @@ impl AcquireFutInner {
     /// We prove that the caller does indeed have mutable access to the node by
     /// passing in a mutable reference to the critical section.
     #[inline]
-    pub fn get_task<'this, 'crit: 'this, C>(
-        self: Pin<&'this mut Self>,
+    pub fn get_task<'crit, C>(
+        self: Pin<&'crit mut Self>,
         critical: &'crit mut C,
-    ) -> (&'crit mut C, &'this mut Node<Task>)
+    ) -> (&'crit mut C, &'crit mut Node<Task>)
     where
         C: IsCritical,
     {
@@ -1460,7 +1460,7 @@ where
                 // This is tested for in the `test_idle` suite of tests.
                 let tokens =
                     if let Some((tokens, deadline)) = lim.calculate_drain(critical.deadline, now) {
-                        trace!(tokens = tokens, "inline drain");
+                        trace!(tokens, "inline drain");
                         // We pre-emptively update the deadline of the core
                         // since it might bump, and we don't want other
                         // processes to observe that the deadline has been

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -254,11 +254,6 @@ impl<T> LinkedList<T> {
     pub(crate) unsafe fn front(&mut self) -> Option<ptr::NonNull<Node<T>>> {
         self.head
     }
-
-    /// Test if the list is empty.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.head.is_none()
-    }
 }
 
 impl<T> fmt::Debug for LinkedList<T> {

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -1,0 +1,26 @@
+use leaky_bucket::RateLimiter;
+use tokio::time::{Duration, Instant};
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn test_numerical_limits() {
+    let limiter = RateLimiter::builder().refill(usize::MAX).initial(0).build();
+    let start = Instant::now();
+
+    limiter.acquire(usize::MAX).await;
+    // Drain the remainder, this should not block.
+    limiter.acquire(isize::MAX as usize - 1).await;
+
+    // This takes 300ms because isize::MAX is one off from half of usize::MAX,
+    // so we need to wait for three periods to satisfy usize::MAX.
+    assert_eq!(
+        Instant::now().duration_since(start),
+        Duration::from_millis(300)
+    );
+
+    // This will block for 100ms to refill the bucket.
+    limiter.acquire(1).await;
+    assert_eq!(
+        Instant::now().duration_since(start),
+        Duration::from_millis(400)
+    );
+}

--- a/tests/test_fast_path.rs
+++ b/tests/test_fast_path.rs
@@ -1,0 +1,44 @@
+use std::future::Future;
+use std::pin::pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::thread;
+
+use leaky_bucket::RateLimiter;
+
+struct Waker;
+
+impl std::task::Wake for Waker {
+    fn wake(self: Arc<Self>) {}
+}
+
+#[test]
+fn test_fast_paths() {
+    let limiter = Arc::new(
+        RateLimiter::builder()
+            .max(10000)
+            .initial(10000)
+            .fair(false)
+            .build(),
+    );
+
+    let mut threads = Vec::new();
+
+    for _ in 0..100 {
+        let limiter = limiter.clone();
+
+        threads.push(thread::spawn(move || {
+            let waker = Arc::new(Waker).into();
+            let mut cx = Context::from_waker(&waker);
+
+            for _ in 0..100 {
+                let acquire = pin!(limiter.acquire(1));
+                assert!(acquire.poll(&mut cx).is_ready());
+            }
+        }));
+    }
+
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}


### PR DESCRIPTION
This re-introduces the fast path implementation, but only if `Builder::fair` is set to `false`.

The fast path is implemented as a spinning compare exchange over the existing token balance. So if tokens happen to be visible during an acquire, a task can try to acquire it immediately.

This however fails if the state cannot be restored, and the task then falls over to the slower locking path.