### PR TITLE
Idle bucket should not overflow

### DIFF
--- a/tests/test_idle.rs
+++ b/tests/test_idle.rs
@@ -16,8 +16,6 @@ async fn test_idle_1() {
     time::sleep(Duration::from_millis(10000)).await;
 
     let start = Instant::now();
-    // This one is "free", since we've slept before acquiring it.
-    limiter.acquire_one().await;
 
     // These ones drain the available permits.
     for _ in 0..5 {
@@ -48,8 +46,6 @@ async fn test_idle_2() {
 
     time::sleep(Duration::from_millis(10000)).await;
 
-    // This one is "free", since it is within the time window we've slept.
-    limiter.acquire_one().await;
     let start = Instant::now();
 
     for _ in 0..5 {


### PR DESCRIPTION
This fixes an issue where if a sufficiently period between two acquire's happens, any number of tokens can be acquired from the bucket.

This changes the logic to work in according with the principle that the token bucket can only be filled up to a certain amount. So if an acquire happens after a long period of time, we will still limit the number of tokens available to that task.